### PR TITLE
feat: Implement Piece Count Display Below Player Avatar

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23,7 +23,7 @@ class App {
   session = {
     /**
      * Check the current session.
-     * @returns {Promise<object>} The session data.
+     * @returns {Promise<Object>} The session data.
      */
     async check() {
       try {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1000,16 +1000,16 @@ class GameUI {
 
     piecesElementList.innerHTML = "";
 
-    const pieceCountMap = pieces.reduce((acc, piece) => {
+    const pieceCountMap = pieces.reduce((acc, piece, i) => {
       const key = `${piece.a.color}-${piece.h.color}`;
       if (!acc[key]) {
-        acc[key] = { piece, count: 0 };
+        acc[key] = { piece, count: 0, index: i };
       }
       acc[key].count += 1;
       return acc;
     }, {});
 
-    Object.values(pieceCountMap).forEach(({ piece, count }, index) => {
+    Object.values(pieceCountMap).forEach(({ piece, count, index }) => {
       const pieceContainer = document.createElement("div");
       pieceContainer.className = "relative w-12 cursor-pointer";
 

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -453,7 +453,9 @@ class GameUI {
           player.name
         } <span id="game-player-${
         player.id
-      }-points" class="font-semibold text-blue-600">(0)</span></span>
+      }-points" class="font-semibold text-blue-600">(0)</span><span id="game-player-${
+        player.id
+      }-pieces" class="font-semibold text-green-600">[0]</span></span>
       </div>
     `;
       playersElement.innerHTML += playerElement;
@@ -1267,6 +1269,18 @@ class GameUI {
       `game-player-${playerId}-points`
     );
     playerScore.innerText = `(${points})`;
+  }
+
+  /**
+   * Update the player pieces.
+   * @param {string} playerId - The player ID.
+   * @param {number} pieces - The player pieces.
+   */
+  updatePlayerPieces(playerId, pieces) {
+    const playerPieces = document.getElementById(
+      `game-player-${playerId}-pieces`
+    );
+    playerPieces.innerText = `[${pieces}]`;
   }
 
   /**

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1809,6 +1809,10 @@ class Game {
 
     this.network.addListener("game:pieces", (data) => {
       this.pieces = data.players;
+
+      for (const player of this.pieces) {
+        this.ui.updatePlayerPieces(player.id, player.pieces.length);
+      }
     });
 
     this.network.addListenerOnce("game:start", () => {


### PR DESCRIPTION
### Summary:

Implemented a new feature that displays the count of pieces a player has directly below their avatar in the game UI. This change enhances the user experience by providing quick, accessible information during gameplay.

### Related Issues:

Closes #30 

### Changes:

- Added a UI component to display the piece count below each player avatar.
- Integrated the piece count with the backend data to ensure real-time updates.
- Adjusted styling to align with the existing UI design.

### Screenshots:

![Screenshot_20241103_140330](https://github.com/user-attachments/assets/6442748f-7812-452a-8616-a80c670412f8)