### PR TITLE
feat: Disable "Join" Button When Room is Full in Game Lobby

### DIFF
--- a/views/pages/rooms.ejs
+++ b/views/pages/rooms.ejs
@@ -145,8 +145,8 @@
                                 </div>
                             `).join("")}
                         </div>
-                        <button class="absolute bottom-4 right-4 py-2 px-4 bg-green-500 text-white font-bold rounded hover:bg-green-600" onclick="window.location.href = '/game?type=join&roomId=${room.roomId}'">
-                            Join
+                        <button class="absolute bottom-4 right-4 py-2 px-4 ${room.players.length === room.maxPlayers ? 'bg-gray-400 cursor-not-allowed' : 'bg-green-500 hover:bg-green-600'} text-white font-bold rounded" ${room.players.length === room.maxPlayers ? 'disabled' : `onclick="window.location.href = '/game?type=join&roomId=${room.roomId}'"`}>
+                            ${room.players.length === room.maxPlayers ? 'Room Full' : 'Join'}
                         </button>
                     `;
                     roomList.appendChild(roomItem);
@@ -186,8 +186,8 @@
                                 </div>
                             `).join("")}
                         </div>
-                        <button class="absolute bottom-4 right-4 py-2 px-4 bg-green-500 text-white font-bold rounded hover:bg-green-600" onclick="window.location.href = '/game?type=join&roomId=${data.room.roomId}'">
-                            Join
+                        <button class="absolute bottom-4 right-4 py-2 px-4 ${data.room.players.length === data.room.maxPlayers ? 'bg-gray-400 cursor-not-allowed' : 'bg-green-500 hover:bg-green-600'} text-white font-bold rounded" ${data.room.players.length === data.room.maxPlayers ? 'disabled' : `onclick="window.location.href = '/game?type=join&roomId=${data.room.roomId}'"`}>
+                            ${data.room.players.length === data.room.maxPlayers ? 'Room Full' : 'Join'}
                         </button>
                     `;
                     roomList.insertBefore(newRoomItem, roomList.firstChild);
@@ -221,8 +221,8 @@
                                 </div>
                             `).join("")}
                         </div>
-                        <button class="absolute bottom-4 right-4 py-2 px-4 bg-green-500 text-white font-bold rounded hover:bg-green-600" onclick="window.location.href = '/game?type=join&roomId=${data.room.roomId}'">
-                            Join
+                        <button class="absolute bottom-4 right-4 py-2 px-4 ${data.room.players.length === data.room.maxPlayers ? 'bg-gray-400 cursor-not-allowed' : 'bg-green-500 hover:bg-green-600'} text-white font-bold rounded" ${data.room.players.length === data.room.maxPlayers ? 'disabled' : `onclick="window.location.href = '/game?type=join&roomId=${data.room.roomId}'"`}>
+                            ${data.room.players.length === data.room.maxPlayers ? 'Room Full' : 'Join'}
                         </button>
                     `;
                 } else if (data.type === "delete") {


### PR DESCRIPTION
### Summary:

Implemented logic to disable the "Join" button for game rooms in the game lobby (homepage) once the room has reached its maximum player capacity.

### Related Issues:

Closes #49

### Changes:

- Implemented logic to disable the "Join" button for game rooms in the game lobby (homepage) once the room has reached its maximum player capacity.
- Added dynamic checks to determine the room status before rendering the "Join" button.
- Disabled the "Join" button and applied a grayed-out style when the room is full.
- Ensured that the button does not respond to user clicks when the room is full, preventing attempts to join a full room.
- Updated the room list rendering logic in `rooms.ejs` to reflect these changes.

### Screenshots:

![Screenshot_20241108_135324](https://github.com/user-attachments/assets/2ff1d8ef-2a14-419a-ac56-22082f5be202)