### PR TITLE
feat: Add How to Play Page to Navigation Bar

### DIFF
--- a/views/components/main-header.ejs
+++ b/views/components/main-header.ejs
@@ -12,6 +12,8 @@
                 class="mr-5 <%= currentPage === 'play-now' ? 'text-gray-900' : 'hover:text-gray-900' %>">Play Now</a>
             <a href="/leaderboard"
                 class="mr-5 <%= currentPage === 'leaderboard' ? 'text-gray-900' : 'hover:text-gray-900' %>">Leaderboard</a>
+            <a href="https://tridecco.com/instructions" 
+                target="_blank" class="mr-5 hover:text-gray-900">How to Play</a>
         </nav>
         <button onclick="window.location.href = '/my'"
             class="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0">My


### PR DESCRIPTION
### Summary:

Added a "How to Play" link to the navigation bar, temporarily linking to an external URL for game instructions. A dedicated "Game Rules" page will be created in the future.

### Related Issues:

Related to #59

### Changes:

- Added a "How to Play" link to the navigation bar in `main-header.ejs`.
- Temporarily linked the "How to Play" page to an external URL: https://tridecco.com/instructions.
- Ensured the link opens in a new tab for user convenience.

This enhancement provides users with easy access to game instructions. A dedicated "Game Rules" page will be designed and implemented in the future to provide detailed instructions for players on how to play the game.