### PR TITLE
Revert "feat: Remove Display of Email in Profile"

### DIFF
--- a/views/pages/users/profile.ejs
+++ b/views/pages/users/profile.ejs
@@ -44,6 +44,7 @@
                             alt="User Avatar">
                         <div class="ml-4 relative">
                             <h3 id="username" class="text-xl font-semibold text-gray-900">Loading...</h3>
+                            <p id="user-email" class="text-sm text-gray-500">Loading...</p>
                         </div>
                     </div>
 
@@ -107,6 +108,7 @@
 
             // Display username, email
             document.getElementById("username").textContent = userData.username;
+            document.getElementById("user-email").textContent = userData.email;
 
             // Display user gender (SVG icons)
             if (userData.profile.gender !== null) {


### PR DESCRIPTION
This reverts PR #65, which temporarily removed email rendering on the frontend.

The initial purpose of PR #65 was to protect user privacy by removing email addresses from being displayed on the frontend. However, in [PR #65](https://github.com/tridecco/game-server/pull/65), implemented backend masking to handle privacy concerns by replacing sensitive email content with asterisks (****).

Restoring email rendering on the frontend avoids layout issues caused by missing email content and ensures better usability, while still maintaining privacy through backend masking.