### PR TITLE
fix: Clear All Event Listeners After Game Ends

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -169,6 +169,18 @@ class GameNetwork {
   removeListener(event, listener) {
     this.socket.off(event, listener);
   }
+
+  /**
+   * Remove all listeners.
+   * @param {string} [event] - The event name. (Optional)
+   */
+  removeAllListeners(event) {
+    if (event) {
+      this.socket.removeAllListeners(event);
+    } else {
+      this.socket.removeAllListeners();
+    }
+  }
 }
 
 /**

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -2341,6 +2341,8 @@ class Game {
         }
       }, 2000);
 
+      this.network.removeAllListeners();
+
       this.ui.stopPreventSleep();
 
       this.audio.stop("countdown");


### PR DESCRIPTION
### Summary:

Fixed the issue where the disconnect event listener triggers incorrectly after the game ends by clearing all event listeners.

### Related Issues:

Closes #71

### Changes:

- Added a new method `removeAllListeners` to the GameNetwork class to allow for the removal of all event listeners.
- Added logic to clear all event listeners in the `game:end` event handler to prevent incorrect triggering of disconnection messages after the game ends.
- Implemented `this.network.removeAllListeners()` in the `game:end` event handler to ensure proper cleanup of event listeners.