### PR TITLE
fix: Adjust Margin for Game Mode to Ensure the "Leave" Button is Fully Visible

### DIFF
--- a/views/components/game/room.ejs
+++ b/views/components/game/room.ejs
@@ -1,7 +1,7 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="mx-auto w-full max-w-md p-4 border border-gray-300 rounded-lg shadow-sm bg-gray-50 relative">
         <button id="exit-room" class="absolute top-4 left-4 text-red-600">Leave</button>
-        <h2 class="text-center text-2xl font-bold mb-4">Game Mode: <span id="room-mode" class="font-semibold"></span></h2>
+        <h2 class="text-center text-2xl font-bold mt-6 mb-4">Game Mode: <span id="room-mode" class="font-semibold"></span></h2>
         <p id="room-status" class="text-center text-lg mb-6">Waiting for Players...</p>
         <div class="mb-6 p-4 border border-gray-300 rounded-lg bg-gray-100 flex items-center justify-between shadow-sm">
             <input type="text" id="room-id" class="w-full max-w-xs border border-gray-300 rounded-lg p-2 text-center bg-white" value="" readonly>


### PR DESCRIPTION
### Summary:

Fixed the issue where the "Leave" button was obstructed by text, making it difficult to click. Adjusted the UI margins to ensure the button remains fully visible and accessible at all times.

### Related Issues:

Closes #75 

### Changes:

- Increased the top margin of the game mode text to prevent overlap with the "Leave" button.
- Verified that the "Leave" button remains clickable in all UI states.